### PR TITLE
chore(did_web): use `spruceid/ssi` fork (excluded `openssl`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,8 +1048,8 @@ dependencies = [
  "multibase 0.8.0",
  "serde_jcs",
  "serde_json",
- "ssi-dids",
- "ssi-jwk",
+ "ssi-dids 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "static-iref",
 ]
 
@@ -1089,23 +1089,22 @@ dependencies = [
  "p256 0.13.2",
  "serde_json",
  "simple_asn1",
- "ssi-crypto",
- "ssi-dids",
- "ssi-jwk",
+ "ssi-crypto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-dids 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
 [[package]]
 name = "did-web"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e239187ee5cf6b778c75252ad22bb8289508dcaf05a7c718222a3093460ca0d2"
+source = "git+https://github.com/impierce/spruceid-ssi.git#192a1fab2eb8e8113fd9aea42ac0fcbb72044d5f"
 dependencies = [
  "async-trait",
  "http",
  "reqwest",
  "serde_json",
- "ssi-dids",
+ "ssi-dids 0.1.1 (git+https://github.com/impierce/spruceid-ssi.git)",
 ]
 
 [[package]]
@@ -1134,8 +1133,8 @@ dependencies = [
  "log",
  "serde_json",
  "shared",
- "ssi-dids",
- "ssi-jwk",
+ "ssi-dids 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-log",
  "tokio",
 ]
@@ -1153,8 +1152,8 @@ dependencies = [
  "log",
  "serde_json",
  "shared",
- "ssi-dids",
- "ssi-jwk",
+ "ssi-dids 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-log",
  "tokio",
 ]
@@ -1197,8 +1196,8 @@ dependencies = [
  "log",
  "serde_json",
  "shared",
- "ssi-dids",
- "ssi-jwk",
+ "ssi-dids 0.1.1 (git+https://github.com/impierce/spruceid-ssi.git)",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-log",
  "tokio",
  "url",
@@ -1589,21 +1588,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2103,19 +2087,6 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -3106,24 +3077,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3253,58 +3206,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
-dependencies = [
- "bitflags 2.5.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.60",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-src"
-version = "300.2.3+3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "p256"
@@ -3936,12 +3841,10 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3953,7 +3856,6 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -4585,7 +4487,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2c479690955bebece0279a5b1ab9d7d584402caed9f56ecec346d0bc63661f"
 dependencies = [
  "bs58",
- "ssi-jwk",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "ssi-caips"
+version = "0.1.0"
+source = "git+https://github.com/impierce/spruceid-ssi.git#192a1fab2eb8e8113fd9aea42ac0fcbb72044d5f"
+dependencies = [
+ "bs58",
+ "ssi-jwk 0.1.2 (git+https://github.com/impierce/spruceid-ssi.git)",
  "thiserror",
 ]
 
@@ -4594,6 +4506,11 @@ name = "ssi-contexts"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3009b82cbae3d88a76f15460fb5fb3f30a1673eb0359ac6917ffaa3c57f7164"
+
+[[package]]
+name = "ssi-contexts"
+version = "0.1.5"
+source = "git+https://github.com/impierce/spruceid-ssi.git#192a1fab2eb8e8113fd9aea42ac0fcbb72044d5f"
 
 [[package]]
 name = "ssi-core"
@@ -4607,10 +4524,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssi-core"
+version = "0.1.0"
+source = "git+https://github.com/impierce/spruceid-ssi.git#192a1fab2eb8e8113fd9aea42ac0fcbb72044d5f"
+dependencies = [
+ "async-trait",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "ssi-crypto"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c511fdba8466006f4de1086fee5f38fd220eac5eeaf0270dbfde3e9d538030e7"
+dependencies = [
+ "bs58",
+ "digest 0.9.0",
+ "k256",
+ "keccak-hash",
+ "ripemd160",
+ "sha2 0.10.8",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "ssi-crypto"
+version = "0.1.1"
+source = "git+https://github.com/impierce/spruceid-ssi.git#192a1fab2eb8e8113fd9aea42ac0fcbb72044d5f"
 dependencies = [
  "bs58",
  "digest 0.9.0",
@@ -4639,10 +4581,34 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "ssi-caips",
- "ssi-core",
- "ssi-json-ld",
- "ssi-jwk",
+ "ssi-caips 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-json-ld 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-jwk 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static-iref",
+ "thiserror",
+]
+
+[[package]]
+name = "ssi-dids"
+version = "0.1.1"
+source = "git+https://github.com/impierce/spruceid-ssi.git#192a1fab2eb8e8113fd9aea42ac0fcbb72044d5f"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bs58",
+ "chrono",
+ "derive_builder",
+ "hex",
+ "iref",
+ "multibase 0.8.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "ssi-caips 0.1.0 (git+https://github.com/impierce/spruceid-ssi.git)",
+ "ssi-core 0.1.0 (git+https://github.com/impierce/spruceid-ssi.git)",
+ "ssi-json-ld 0.2.2 (git+https://github.com/impierce/spruceid-ssi.git)",
+ "ssi-jwk 0.1.2 (git+https://github.com/impierce/spruceid-ssi.git)",
  "static-iref",
  "thiserror",
 ]
@@ -4663,8 +4629,29 @@ dependencies = [
  "lazy_static",
  "locspan",
  "rdf-types",
- "ssi-contexts",
- "ssi-crypto",
+ "ssi-contexts 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssi-crypto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static-iref",
+ "thiserror",
+]
+
+[[package]]
+name = "ssi-json-ld"
+version = "0.2.2"
+source = "git+https://github.com/impierce/spruceid-ssi.git#192a1fab2eb8e8113fd9aea42ac0fcbb72044d5f"
+dependencies = [
+ "async-std",
+ "combination",
+ "futures",
+ "grdf",
+ "iref",
+ "json-ld",
+ "json-syntax",
+ "lazy_static",
+ "locspan",
+ "rdf-types",
+ "ssi-contexts 0.1.5 (git+https://github.com/impierce/spruceid-ssi.git)",
+ "ssi-crypto 0.1.1 (git+https://github.com/impierce/spruceid-ssi.git)",
  "static-iref",
  "thiserror",
 ]
@@ -4689,7 +4676,26 @@ dependencies = [
  "rsa",
  "serde",
  "simple_asn1",
- "ssi-crypto",
+ "ssi-crypto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "unsigned-varint",
+ "zeroize",
+]
+
+[[package]]
+name = "ssi-jwk"
+version = "0.1.2"
+source = "git+https://github.com/impierce/spruceid-ssi.git#192a1fab2eb8e8113fd9aea42ac0fcbb72044d5f"
+dependencies = [
+ "base64 0.12.3",
+ "lazy_static",
+ "multibase 0.9.1",
+ "num-bigint",
+ "num-derive 0.3.3",
+ "num-traits",
+ "serde",
+ "simple_asn1",
+ "ssi-crypto 0.1.1 (git+https://github.com/impierce/spruceid-ssi.git)",
  "thiserror",
  "unsigned-varint",
  "zeroize",
@@ -4864,18 +4870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tempfile"
-version = "3.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
-dependencies = [
- "cfg-if",
- "fastrand 2.0.2",
- "rustix 0.38.32",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "test-log"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4999,16 +4993,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -5231,12 +5215,6 @@ name = "value-bag"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/did_web/Cargo.toml
+++ b/did_web/Cargo.toml
@@ -9,13 +9,13 @@ rust-version.workspace = true
 
 [dependencies]
 shared = { path = "../shared" }
-did-web-extern = { version = "0.2.2", package = "did-web" }
+did-web-extern = { git = "https://github.com/impierce/spruceid-ssi.git", package = "did-web" }
 identity_iota.workspace = true
 identity_stronghold.workspace = true
 iota-sdk.workspace = true
 log.workspace = true
 serde_json.workspace = true
-ssi-dids = "0.1.1"
+ssi-dids = { git = "https://github.com/impierce/spruceid-ssi.git" }
 ssi-jwk = "0.1.2"
 tokio.workspace = true
 url = "2.5"


### PR DESCRIPTION
# Description of change
We forked [spruceid/ssi](https://github.com/spruceid/ssi) (`976e260`) as [impierce/spruceid-ssi](https://github.com/impierce/spruceid-ssi) to remove the dependency on `openssl` for Android builds.

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes