### PR TITLE
refactor: externalize method-specific parameters for `did:web`

### DIFF
--- a/did_web/src/producer.rs
+++ b/did_web/src/producer.rs
@@ -13,8 +13,7 @@ use std::io::Error;
 pub async fn produce_did_web(
     storage: JwkStorageWrapper,
     key_id: &KeyId,
-    host: url::Host,
-    port: Option<u16>,
+    origin: url::Origin,
 ) -> Result<CoreDocument, Error> {
     // TODO: check if key exists for given key_id?
 
@@ -25,21 +24,19 @@ pub async fn produce_did_web(
 
     info!("Producing did:web for key_id=[{:?}] ...", key_id.as_str());
 
-    // Construct the URL from host and (optional) port
-    // TODO: is there a better default than having to parse to create a new Url?
-    let mut url = url::Url::parse("https://example.net").unwrap();
-    url.set_host(Some(&host.to_string())).unwrap();
-    url.set_port(port).unwrap();
+    debug!("Origin: {}", &origin.ascii_serialization());
 
-    debug!("HOST: {}", url.as_str());
-
-    let host_port = if port.is_some() {
-        format!("{}:{}", url.host_str().unwrap(), url.port().unwrap())
-    } else {
-        url.host_str().unwrap().to_string()
+    let (scheme, host, port) = match origin {
+        url::Origin::Tuple(ref scheme, ref host, ref port) => (scheme, host, port),
+        url::Origin::Opaque(_) => {
+            return Err(Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Opaque origin not supported",
+            ));
+        }
     };
 
-    let host_port_encoded = urlencoding::encode(&host_port);
+    let host_port_encoded = urlencoding::encode(format!("{}:{}", host, port).as_str()).to_string();
 
     let did_str = format!("did:web:{}", host_port_encoded);
 
@@ -65,9 +62,11 @@ pub async fn produce_did_web(
         .build()
         .unwrap();
 
+    let well_known = format!("{}/.well-known/did.json", origin.ascii_serialization());
+
     info!("Host the following json under the following url:");
     info!("================================================");
-    info!("{}", url.join(".well-known/did.json").unwrap());
+    info!("{}", well_known);
     info!("================================================");
     info!("{}", document.to_json_pretty().unwrap());
     info!("================================================");
@@ -99,8 +98,11 @@ mod tests {
         let document = produce_did_web(
             JwkStorageWrapper::Stronghold(stronghold_storage),
             &key_id,
-            url::Host::parse("localhost").unwrap(),
-            Some(mock_server_port),
+            url::Origin::Tuple(
+                "http".to_string(),
+                url::Host::Domain("localhost".to_string()),
+                mock_server_port,
+            ),
         )
         .await
         .unwrap();

--- a/did_web/src/producer.rs
+++ b/did_web/src/producer.rs
@@ -26,7 +26,7 @@ pub async fn produce_did_web(
 
     debug!("Origin: {}", &origin.ascii_serialization());
 
-    let (scheme, host, port) = match origin {
+    let (_scheme, host, port) = match origin {
         url::Origin::Tuple(ref scheme, ref host, ref port) => (scheme, host, port),
         url::Origin::Opaque(_) => {
             return Err(Error::new(

--- a/producer/src/did_document.rs
+++ b/producer/src/did_document.rs
@@ -30,7 +30,7 @@ impl std::fmt::Display for DidMethod {
 
 /// Some DID methods require additional parameters for producing a document.
 pub enum MethodSpecificParameters {
-    Web { host: url::Host, port: Option<u16> },
+    Web { origin: url::Origin },
 }
 
 impl SecretManager {
@@ -53,15 +53,15 @@ impl SecretManager {
                 Some(core_document)
             }
             DidMethod::Web => {
-                let (host, port) = match method_specific_parameters {
-                    Some(MethodSpecificParameters::Web { host, port }) => (host, port),
+                let origin = match method_specific_parameters {
+                    Some(MethodSpecificParameters::Web { origin }) => origin,
                     None => {
                         return Err(ProducerError::Generic(
                             "Missing method-specific parameters for `did:web`".to_string(),
                         ))
                     }
                 };
-                let core_document = did_web::producer::produce_did_web(storage, &self.key_id, host, port)
+                let core_document = did_web::producer::produce_did_web(storage, &self.key_id, origin)
                     .await
                     .unwrap();
                 Some(core_document)

--- a/producer/src/did_document.rs
+++ b/producer/src/did_document.rs
@@ -28,12 +28,18 @@ impl std::fmt::Display for DidMethod {
     }
 }
 
-impl SecretManager {
-    pub async fn produce_document(&self, did_method: DidMethod) -> Result<CoreDocument, ProducerError> {
-        let storage = JwkStorageWrapper::Stronghold(self.stronghold_storage.clone());
+/// Some DID methods require additional parameters for producing a document.
+pub enum MethodSpecificParameters {
+    Web { host: url::Host, port: Option<u16> },
+}
 
-        let host: url::Host = url::Host::parse("localhost").unwrap(); // TODO
-        let port: Option<u16> = None; // TODO: default?
+impl SecretManager {
+    pub async fn produce_document(
+        &self,
+        did_method: DidMethod,
+        method_specific_parameters: Option<MethodSpecificParameters>,
+    ) -> Result<CoreDocument, ProducerError> {
+        let storage = JwkStorageWrapper::Stronghold(self.stronghold_storage.clone());
 
         let core_document: Option<CoreDocument> = match did_method {
             DidMethod::Jwk => {
@@ -47,6 +53,14 @@ impl SecretManager {
                 Some(core_document)
             }
             DidMethod::Web => {
+                let (host, port) = match method_specific_parameters {
+                    Some(MethodSpecificParameters::Web { host, port }) => (host, port),
+                    None => {
+                        return Err(ProducerError::Generic(
+                            "Missing method-specific parameters for `did:web`".to_string(),
+                        ))
+                    }
+                };
                 let core_document = did_web::producer::produce_did_web(storage, &self.key_id, host, port)
                     .await
                     .unwrap();
@@ -130,8 +144,7 @@ mod tests {
         .await
         .unwrap();
 
-        // TODO: Some(url::Host::parse("localhost").unwrap()), Some(8080)
-        let document = secret_manager.produce_document(DidMethod::Web).await;
+        let document = secret_manager.produce_document(DidMethod::Jwk, None).await;
 
         info!("Document: {}", document.as_ref().unwrap().to_json_pretty().unwrap());
         assert!(document.is_ok())
@@ -149,8 +162,7 @@ mod tests {
         .await
         .unwrap();
 
-        // TODO: Some(url::Host::parse("localhost").unwrap()), Some(8080)
-        let document = secret_manager.produce_document(DidMethod::Web).await;
+        let document = secret_manager.produce_document(DidMethod::Jwk, None).await;
 
         assert_eq!(
             document

--- a/producer/src/lib.rs
+++ b/producer/src/lib.rs
@@ -2,5 +2,6 @@ pub mod did_document;
 pub mod secret_manager;
 pub mod signature;
 
+pub use crate::did_document::MethodSpecificParameters;
 pub use crate::secret_manager::SecretManager;
 pub use identity_iota::document::CoreDocument;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub use consumer::resolver::Resolver;
 pub use producer::did_document::DidMethod;
+pub use producer::MethodSpecificParameters;
 pub use producer::SecretManager;


### PR DESCRIPTION
# Description of change

- parameters are required when producing certain DIDs, such as the `origin` for `did:web`
- refactor: simplify `host: url::Host, port: Option<u16>` to `origin: url::Origin`

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes