### PR TITLE
feat: change visibility of `stronghold_storage` to `pub`

### DIFF
--- a/producer/src/secret_manager.rs
+++ b/producer/src/secret_manager.rs
@@ -12,7 +12,7 @@ use std::io::{Error, ErrorKind};
 /// Generates or loads a Stronghold and uses the specified `KeyId` for all cryptographic operations
 #[derive(Clone)]
 pub struct SecretManager {
-    pub(crate) stronghold_storage: StrongholdStorage,
+    pub stronghold_storage: StrongholdStorage,
     pub(crate) key_id: KeyId,
     pub(crate) did: Option<String>, // TODO(selv): externally managed DID (see did_iota/README.md)
     pub(crate) fragment: Option<String>, // TODO(selv): externally managed fragment (see did_iota/README.md)


### PR DESCRIPTION
# Description of change
Change visibility of `stronghold_storage` from `pub(crate)` to `pub` to be accessible from outside.

## Links to any relevant issues
n/a

## How the change has been tested
n/a

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes