### PR TITLE
chore: omit default https port, disallow IP addresses

### DIFF
--- a/did_web/src/consumer.rs
+++ b/did_web/src/consumer.rs
@@ -33,7 +33,7 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test(tokio::test)]
-    async fn resolves_did_web_ed25519() {
+    async fn resolves_did_web_with_ed25519_key() {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))

--- a/did_web/src/producer.rs
+++ b/did_web/src/producer.rs
@@ -33,7 +33,22 @@ pub async fn produce_did_web(
         }
     };
 
-    let host_port_encoded = urlencoding::encode(format!("{}:{}", host, port).as_str()).to_string();
+    // IP addresses are not allowed
+    match host {
+        url::Host::Domain(_) => {}
+        url::Host::Ipv4(_) => {
+            return Err(ProducerError::Generic("IPv4 address not allowed".to_string()));
+        }
+        url::Host::Ipv6(_) => {
+            return Err(ProducerError::Generic("IPv6 address not allowed".to_string()));
+        }
+    }
+
+    // Omit default HTTPS port
+    let host_port_encoded = match port {
+        443 => host.to_string(),
+        _ => urlencoding::encode(format!("{}:{}", host, port).as_str()).to_string(),
+    };
 
     let did_str = format!("did:web:{}", host_port_encoded);
 
@@ -90,6 +105,8 @@ fn get_properties(method_type: MethodType) -> BTreeMap<String, serde_json::Value
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+
     use super::*;
 
     use crate::consumer::resolve_did_web;
@@ -102,7 +119,7 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test(tokio::test)]
-    async fn produces_did_web_ed25519() {
+    async fn produces_did_web_with_ed25519_key() {
         let (stronghold_storage, key_id, _) = new_stronghold_storage().await;
 
         let mock_server = MockServer::start().await;
@@ -155,5 +172,36 @@ mod tests {
               ]
             })
         );
+    }
+
+    #[test(tokio::test)]
+    async fn default_https_port_is_omitted() {
+        let (stronghold_storage, key_id, _) = new_stronghold_storage().await;
+
+        let document = produce_did_web(
+            JwkStorageWrapper::Stronghold(stronghold_storage),
+            key_id.as_str(),
+            url::Origin::Tuple("https".to_string(), url::Host::Domain("example.org".to_string()), 443),
+            JwsAlgorithm::EdDSA,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(document.id().to_string(), "did:web:example.org");
+    }
+
+    #[test(tokio::test)]
+    async fn fails_for_ip_address() {
+        let (stronghold_storage, key_id, _) = new_stronghold_storage().await;
+
+        let document = produce_did_web(
+            JwkStorageWrapper::Stronghold(stronghold_storage),
+            key_id.as_str(),
+            url::Origin::Tuple("https".to_string(), url::Host::Ipv4(Ipv4Addr::new(1, 1, 1, 1)), 443),
+            JwsAlgorithm::EdDSA,
+        )
+        .await;
+
+        assert!(document.is_err());
     }
 }


### PR DESCRIPTION
# Description of change

- default https port (`443`) is omitted when constructing the DID method-specific identifier (host) from the given origin
- IP addresses are disallowed (as defined [in the spec](https://w3c-ccg.github.io/did-method-web/#method-specific-identifier))

## Links to any relevant issues

- fixes #25 

## How the change has been tested
All tests pass.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes