### PR TITLE
chore: disable `default-features` in `identity_iota` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ repository = "https://github.com/impierce/did-manager"
 rust-version = "1.75"
 
 [workspace.dependencies]
-identity_iota = { version = "1.3" }
+identity_iota = { version = "1.3", default-features = false, features = ["resolver", "iota-client"] }
 identity_storage = { version = "1.3", default-features = false }
 identity_stronghold = { version = "1.3", features = ["send-sync-storage"] }
 iota-sdk = { version = "1.1", features = ["stronghold"] }


### PR DESCRIPTION
# Description of change
Updating `identity_iota` from 1.2 to 1.3 introduced an unwanted implicit dependency on `openssl` which causes problems downstream. This PR fixes that by disabling some of its default features.

## Links to any relevant issues
- https://github.com/impierce/identity-wallet/issues/326

## How the change has been tested
Tested by building UniMe through this PR: https://github.com/impierce/identity-wallet/pull/327 (which depends on the change in this PR)

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes