### PR TITLE
fix: retrieve from cache only if `did` is configured

### DIFF
--- a/producer/src/did_document.rs
+++ b/producer/src/did_document.rs
@@ -69,10 +69,13 @@ impl SecretManager {
 
         // Try to retrieve from cache first
         let core_document: Option<CoreDocument> = match &mut self.cache {
-            Some(cache) => {
-                let did = CoreDID::parse(self.did.as_ref().expect("externally managed `DID` not specified"))?;
-                cache.retrieve(&did)
-            }
+            Some(cache) => match &self.did {
+                Some(did) => {
+                    let did = CoreDID::parse(did)?;
+                    cache.retrieve(&did)
+                }
+                None => None,
+            },
             None => None,
         };
 


### PR DESCRIPTION
# Description of change
All DID documents are tried to be retrieved from cache (if enabled), even if there is no "externally managed" DID configured. This failed, while it should just return no cache hit.

## Links to any relevant issues
n/a

## How the change has been tested
Fix has been tested in a local UniCore environment.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes