### PR TITLE
feat: make nodes configurable for IOTA resolvers

### DIFF
--- a/consumer/src/resolver.rs
+++ b/consumer/src/resolver.rs
@@ -23,9 +23,9 @@ impl Resolver {
     pub async fn new_with_options(
         node_urls: Option<NodeUrls>,
         tls_config: Option<rustls::ClientConfig>,
-        set_user_password: Option<(&str, &str)>,
+        basic_auth: Option<(&str, &str)>,
     ) -> Self {
-        let resolver = configure_resolver(IdentityResolver::new(), node_urls, tls_config, set_user_password)
+        let resolver = configure_resolver(IdentityResolver::new(), node_urls, tls_config, basic_auth)
             .await
             .expect("Failed to configure resolver");
         Self { resolver }
@@ -42,14 +42,14 @@ async fn configure_resolver(
     mut resolver: IdentityResolver,
     node_urls: Option<NodeUrls>,
     tls_config: Option<rustls::ClientConfig>,
-    set_user_password: Option<(&str, &str)>,
+    basic_auth: Option<(&str, &str)>,
 ) -> Result<IdentityResolver, ConsumerError> {
     resolver.attach_handler("jwk".to_owned(), resolve_did_jwk);
     resolver.attach_handler("key".to_owned(), resolve_did_key);
     resolver.attach_handler("web".to_owned(), resolve_did_web);
 
     resolver.attach_multiple_iota_handlers(
-        iota_clients(node_urls, tls_config, set_user_password)
+        iota_clients(node_urls, tls_config, basic_auth)
             .await
             .map_err(|e| ConsumerError::Generic(format!("Failed to attach IOTA handlers: {e}")))?,
     );

--- a/consumer/src/resolver.rs
+++ b/consumer/src/resolver.rs
@@ -13,22 +13,8 @@ pub struct Resolver {
 }
 
 impl Resolver {
-    pub async fn new() -> Self {
-        let resolver = configure_resolver(IdentityResolver::new(), None, None)
-            .await
-            .expect("Failed to configure resolver");
-        Self { resolver }
-    }
-
-    pub async fn new_with_node_url(node_url: &str) -> Self {
-        let resolver = configure_resolver(IdentityResolver::new(), Some(node_url), None)
-            .await
-            .expect("Failed to configure resolver");
-        Self { resolver }
-    }
-
-    pub async fn new_with_tls_config(tls_config: rustls::ClientConfig) -> Self {
-        let resolver = configure_resolver(IdentityResolver::new(), None, Some(tls_config))
+    pub async fn new(node_url: Option<&str>, tls_config: Option<rustls::ClientConfig>) -> Self {
+        let resolver = configure_resolver(IdentityResolver::new(), node_url, tls_config)
             .await
             .expect("Failed to configure resolver");
         Self { resolver }
@@ -67,7 +53,7 @@ mod tests {
 
     #[test(tokio::test)]
     async fn resolve_all_supported_methods() {
-        let resolver = Resolver::new().await;
+        let resolver = Resolver::new(None, None).await;
         let did = "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL";
         let document = resolver.resolve(did).await.unwrap();
 
@@ -81,7 +67,7 @@ mod tests {
 
     #[test(tokio::test)]
     async fn fails_on_unsupported_method() {
-        let resolver = Resolver::new().await;
+        let resolver = Resolver::new(None, None).await;
         let did = "did:foo:bar";
         let result = resolver.resolve(did).await;
 
@@ -91,7 +77,7 @@ mod tests {
     #[ignore]
     #[test(tokio::test)]
     async fn resolves_did_iota() {
-        let resolver = Resolver::new().await;
+        let resolver = Resolver::new(None, None).await;
         let did = "did:iota:0xe4edef97da1257e83cbeb49159cfdd2da6ac971ac447f233f8439cf29376ebfe";
         let document = resolver.resolve(did).await.unwrap();
 

--- a/consumer/src/resolver.rs
+++ b/consumer/src/resolver.rs
@@ -21,11 +21,11 @@ impl Resolver {
     }
 
     pub async fn new_with_options(
-        node_urls: Option<NodeUrls>,
         tls_config: Option<rustls::ClientConfig>,
+        node_urls: Option<NodeUrls>,
         basic_auth: Option<(&str, &str)>,
     ) -> Self {
-        let resolver = configure_resolver(IdentityResolver::new(), node_urls, tls_config, basic_auth)
+        let resolver = configure_resolver(IdentityResolver::new(), tls_config, node_urls, basic_auth)
             .await
             .expect("Failed to configure resolver");
         Self { resolver }
@@ -40,8 +40,8 @@ impl Resolver {
 
 async fn configure_resolver(
     mut resolver: IdentityResolver,
-    node_urls: Option<NodeUrls>,
     tls_config: Option<rustls::ClientConfig>,
+    node_urls: Option<NodeUrls>,
     basic_auth: Option<(&str, &str)>,
 ) -> Result<IdentityResolver, ConsumerError> {
     resolver.attach_handler("jwk".to_owned(), resolve_did_jwk);
@@ -49,7 +49,7 @@ async fn configure_resolver(
     resolver.attach_handler("web".to_owned(), resolve_did_web);
 
     resolver.attach_multiple_iota_handlers(
-        iota_clients(node_urls, tls_config, basic_auth)
+        iota_clients(tls_config, node_urls, basic_auth)
             .await
             .map_err(|e| ConsumerError::Generic(format!("Failed to attach IOTA handlers: {e}")))?,
     );

--- a/consumer/src/resolver.rs
+++ b/consumer/src/resolver.rs
@@ -1,4 +1,4 @@
-use did_iota::consumer::iota_clients;
+use did_iota::consumer::{iota_clients, NodeUrls};
 use did_jwk::consumer::resolve_did_jwk;
 use did_key::consumer::resolve_did_key;
 use did_web::consumer::resolve_did_web;
@@ -13,8 +13,12 @@ pub struct Resolver {
 }
 
 impl Resolver {
-    pub async fn new(node_url: Option<&str>, tls_config: Option<rustls::ClientConfig>) -> Self {
-        let resolver = configure_resolver(IdentityResolver::new(), node_url, tls_config)
+    pub async fn new(
+        node_urls: Option<NodeUrls>,
+        tls_config: Option<rustls::ClientConfig>,
+        set_user_password: Option<(&str, &str)>,
+    ) -> Self {
+        let resolver = configure_resolver(IdentityResolver::new(), node_urls, tls_config, set_user_password)
             .await
             .expect("Failed to configure resolver");
         Self { resolver }
@@ -29,15 +33,16 @@ impl Resolver {
 
 async fn configure_resolver(
     mut resolver: IdentityResolver,
-    node_url: Option<&str>,
+    node_urls: Option<NodeUrls>,
     tls_config: Option<rustls::ClientConfig>,
+    set_user_password: Option<(&str, &str)>,
 ) -> Result<IdentityResolver, ConsumerError> {
     resolver.attach_handler("jwk".to_owned(), resolve_did_jwk);
     resolver.attach_handler("key".to_owned(), resolve_did_key);
     resolver.attach_handler("web".to_owned(), resolve_did_web);
 
     resolver.attach_multiple_iota_handlers(
-        iota_clients(node_url, tls_config)
+        iota_clients(node_urls, tls_config, set_user_password)
             .await
             .map_err(|e| ConsumerError::Generic(format!("Failed to attach IOTA handlers: {e}")))?,
     );
@@ -53,7 +58,7 @@ mod tests {
 
     #[test(tokio::test)]
     async fn resolve_all_supported_methods() {
-        let resolver = Resolver::new(None, None).await;
+        let resolver = Resolver::new(None, None, None).await;
         let did = "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL";
         let document = resolver.resolve(did).await.unwrap();
 
@@ -67,7 +72,7 @@ mod tests {
 
     #[test(tokio::test)]
     async fn fails_on_unsupported_method() {
-        let resolver = Resolver::new(None, None).await;
+        let resolver = Resolver::new(None, None, None).await;
         let did = "did:foo:bar";
         let result = resolver.resolve(did).await;
 
@@ -77,7 +82,7 @@ mod tests {
     #[ignore]
     #[test(tokio::test)]
     async fn resolves_did_iota() {
-        let resolver = Resolver::new(None, None).await;
+        let resolver = Resolver::new(None, None, None).await;
         let did = "did:iota:0xe4edef97da1257e83cbeb49159cfdd2da6ac971ac447f233f8439cf29376ebfe";
         let document = resolver.resolve(did).await.unwrap();
 

--- a/consumer/src/resolver.rs
+++ b/consumer/src/resolver.rs
@@ -13,7 +13,14 @@ pub struct Resolver {
 }
 
 impl Resolver {
-    pub async fn new(
+    pub async fn new() -> Self {
+        let resolver = configure_resolver(IdentityResolver::new(), None, None, None)
+            .await
+            .expect("Failed to configure resolver");
+        Self { resolver }
+    }
+
+    pub async fn new_with_options(
         node_urls: Option<NodeUrls>,
         tls_config: Option<rustls::ClientConfig>,
         set_user_password: Option<(&str, &str)>,
@@ -58,7 +65,7 @@ mod tests {
 
     #[test(tokio::test)]
     async fn resolve_all_supported_methods() {
-        let resolver = Resolver::new(None, None, None).await;
+        let resolver = Resolver::new().await;
         let did = "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL";
         let document = resolver.resolve(did).await.unwrap();
 
@@ -72,7 +79,7 @@ mod tests {
 
     #[test(tokio::test)]
     async fn fails_on_unsupported_method() {
-        let resolver = Resolver::new(None, None, None).await;
+        let resolver = Resolver::new().await;
         let did = "did:foo:bar";
         let result = resolver.resolve(did).await;
 
@@ -82,7 +89,7 @@ mod tests {
     #[ignore]
     #[test(tokio::test)]
     async fn resolves_did_iota() {
-        let resolver = Resolver::new(None, None, None).await;
+        let resolver = Resolver::new().await;
         let did = "did:iota:0xe4edef97da1257e83cbeb49159cfdd2da6ac971ac447f233f8439cf29376ebfe";
         let document = resolver.resolve(did).await.unwrap();
 

--- a/consumer/src/resolver.rs
+++ b/consumer/src/resolver.rs
@@ -14,14 +14,21 @@ pub struct Resolver {
 
 impl Resolver {
     pub async fn new() -> Self {
-        let resolver = configure_resolver(IdentityResolver::new(), None)
+        let resolver = configure_resolver(IdentityResolver::new(), None, None)
+            .await
+            .expect("Failed to configure resolver");
+        Self { resolver }
+    }
+
+    pub async fn new_with_node_url(node_url: &str) -> Self {
+        let resolver = configure_resolver(IdentityResolver::new(), Some(node_url), None)
             .await
             .expect("Failed to configure resolver");
         Self { resolver }
     }
 
     pub async fn new_with_tls_config(tls_config: rustls::ClientConfig) -> Self {
-        let resolver = configure_resolver(IdentityResolver::new(), Some(tls_config))
+        let resolver = configure_resolver(IdentityResolver::new(), None, Some(tls_config))
             .await
             .expect("Failed to configure resolver");
         Self { resolver }
@@ -36,13 +43,15 @@ impl Resolver {
 
 async fn configure_resolver(
     mut resolver: IdentityResolver,
+    node_url: Option<&str>,
     tls_config: Option<rustls::ClientConfig>,
 ) -> Result<IdentityResolver, ConsumerError> {
     resolver.attach_handler("jwk".to_owned(), resolve_did_jwk);
     resolver.attach_handler("key".to_owned(), resolve_did_key);
     resolver.attach_handler("web".to_owned(), resolve_did_web);
+
     resolver.attach_multiple_iota_handlers(
-        iota_clients(tls_config)
+        iota_clients(node_url, tls_config)
             .await
             .map_err(|e| ConsumerError::Generic(format!("Failed to attach IOTA handlers: {e}")))?,
     );

--- a/did_iota/src/consumer.rs
+++ b/did_iota/src/consumer.rs
@@ -2,33 +2,35 @@ use identity_iota::iota::rebased::client::IdentityClientReadOnly;
 use identity_iota::iota::rebased::Error;
 use iota_sdk::IotaClientBuilder;
 
-/// Builds clients for all IOTA networks.
+// Helper to create a builder with optional TLS config AND/OR node url
+fn client_builder_with_tls_or_url(
+    tls_config: Option<&rustls::ClientConfig>,
+    node_url: Option<&str>,
+) -> IotaClientBuilder {
+    let mut builder = IotaClientBuilder::default();
+    if let Some(url) = node_url {
+        builder = builder.ws_url(url);
+    }
+    if let Some(cfg) = tls_config {
+        builder = builder.tls_config(cfg.clone());
+    }
+    builder
+}
+
+/// Builds clients for all IOTA networks with optional node URL and/or TLS config.
 pub async fn iota_clients(
+    node_url: Option<&str>,
     tls_config: Option<rustls::ClientConfig>,
 ) -> Result<Vec<(&'static str, IdentityClientReadOnly)>, Error> {
-    let mut iota_testnet_client_builder = IotaClientBuilder::default();
-
-    if let Some(tls_config) = &tls_config {
-        iota_testnet_client_builder = iota_testnet_client_builder.tls_config(tls_config.clone());
-    }
-
-    let iota_testnet = iota_testnet_client_builder.build_testnet().await?;
-
-    let mut iota_devnet_client_builder = IotaClientBuilder::default();
-
-    if let Some(tls_config) = &tls_config {
-        iota_devnet_client_builder = iota_devnet_client_builder.tls_config(tls_config.clone());
-    }
-
-    let iota_devnet = iota_devnet_client_builder.build_devnet().await?;
-
-    let mut iota_mainnet_client_builder = IotaClientBuilder::default();
-
-    if let Some(tls_config) = tls_config {
-        iota_mainnet_client_builder = iota_mainnet_client_builder.tls_config(tls_config);
-    }
-
-    let iota_mainnet = iota_mainnet_client_builder.build_mainnet().await?;
+    let iota_testnet = client_builder_with_tls_or_url(tls_config.as_ref(), node_url)
+        .build_testnet()
+        .await?;
+    let iota_devnet = client_builder_with_tls_or_url(tls_config.as_ref(), node_url)
+        .build_devnet()
+        .await?;
+    let iota_mainnet = client_builder_with_tls_or_url(tls_config.as_ref(), node_url)
+        .build_mainnet()
+        .await?;
 
     Ok(vec![
         ("testnet", IdentityClientReadOnly::new(iota_testnet).await?),

--- a/did_iota/src/consumer.rs
+++ b/did_iota/src/consumer.rs
@@ -1,31 +1,138 @@
 use identity_iota::iota::rebased::client::IdentityClientReadOnly;
 use identity_iota::iota::rebased::Error;
-use iota_sdk::IotaClientBuilder;
+use iota_sdk::{IotaClient, IotaClientBuilder};
 
-// Helper to create a builder with optional TLS config AND/OR node url
-fn client_builder(tls_config: Option<&rustls::ClientConfig>, node_url: Option<&str>) -> IotaClientBuilder {
-    let mut builder = IotaClientBuilder::default();
-    if let Some(url) = node_url {
-        builder = builder.ws_url(url);
+/// Builds clients for all IOTA networks with optional node URL and/or TLS confiuration, only returns an error if it fails to build, incorrect tls_config or node_url isn't caught before trying to build.
+pub async fn iota_clients(
+    node_urls: Option<NodeUrls>,
+    tls_config: Option<rustls::ClientConfig>,
+    set_user_password: Option<(&str, &str)>,
+) -> Result<Vec<(&'static str, IdentityClientReadOnly)>, Error> {
+    let iota_mainnet: IotaClient;
+    let iota_devnet: IotaClient;
+    let iota_testnet: IotaClient;
+    if let Some(urls) = &node_urls {
+        iota_mainnet = match &urls.mainnet {
+            Some(url) => {
+                client_builder(tls_config.as_ref(), set_user_password)
+                    .build(url)
+                    .await?
+            }
+            None => {
+                client_builder(tls_config.as_ref(), set_user_password)
+                    .build_mainnet()
+                    .await?
+            }
+        };
+        iota_devnet = match &urls.devnet {
+            Some(url) => {
+                client_builder(tls_config.as_ref(), set_user_password)
+                    .build(url)
+                    .await?
+            }
+            None => {
+                client_builder(tls_config.as_ref(), set_user_password)
+                    .build_devnet()
+                    .await?
+            }
+        };
+        iota_testnet = match &urls.testnet {
+            Some(url) => {
+                client_builder(tls_config.as_ref(), set_user_password)
+                    .build(url)
+                    .await?
+            }
+            None => {
+                client_builder(tls_config.as_ref(), set_user_password)
+                    .build_testnet()
+                    .await?
+            }
+        };
+    } else {
+        iota_mainnet = client_builder(tls_config.as_ref(), set_user_password)
+            .build_mainnet()
+            .await?;
+        iota_devnet = client_builder(tls_config.as_ref(), set_user_password)
+            .build_devnet()
+            .await?;
+        iota_testnet = client_builder(tls_config.as_ref(), set_user_password)
+            .build_testnet()
+            .await?;
     }
+
+    Ok(vec![
+        ("iota", IdentityClientReadOnly::new(iota_mainnet).await?),
+        ("devnet", IdentityClientReadOnly::new(iota_devnet).await?),
+        ("testnet", IdentityClientReadOnly::new(iota_testnet).await?),
+    ])
+}
+
+// Helpers
+
+// Helper to create a builder with optional TLS config and basic_auth configuration
+fn client_builder(
+    tls_config: Option<&rustls::ClientConfig>,
+    set_user_password: Option<(&str, &str)>,
+) -> IotaClientBuilder {
+    let mut builder = IotaClientBuilder::default();
     if let Some(cfg) = tls_config {
         builder = builder.tls_config(cfg.clone());
+    }
+    if let Some((username, password)) = set_user_password {
+        builder = builder.basic_auth(username, password);
     }
     builder
 }
 
-/// Builds clients for all IOTA networks with optional node URL and/or TLS config, only returns an error if it fails to build, incorrect tls_config or node_url isn't caught before trying to build.
-pub async fn iota_clients(
-    node_url: Option<&str>,
-    tls_config: Option<rustls::ClientConfig>,
-) -> Result<Vec<(&'static str, IdentityClientReadOnly)>, Error> {
-    let iota_testnet = client_builder(tls_config.as_ref(), node_url).build_testnet().await?;
-    let iota_devnet = client_builder(tls_config.as_ref(), node_url).build_devnet().await?;
-    let iota_mainnet = client_builder(tls_config.as_ref(), node_url).build_mainnet().await?;
+/// This struct is to strictly define what is passed as an argument to fn iota_clients()
+/// If None is passed the IOTA default node for that net will be used.
+#[derive(Debug, Clone)]
+pub struct NodeUrls {
+    pub mainnet: Option<String>,
+    pub devnet: Option<String>,
+    pub testnet: Option<String>,
+}
 
-    Ok(vec![
-        ("testnet", IdentityClientReadOnly::new(iota_testnet).await?),
-        ("devnet", IdentityClientReadOnly::new(iota_devnet).await?),
-        ("iota", IdentityClientReadOnly::new(iota_mainnet).await?),
-    ])
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// This is a very basic test which simply checks wether the function completes without error.
+    /// All resulting structs are private in the identity.rs crates, therefore no assertions can be made.
+    /// See the second test for a more in-depth test.
+    #[tokio::test]
+    async fn test_iota_clients_node_urls() {
+        let node_urls = NodeUrls {
+            mainnet: Some("https://rpc.mainnet.iota.monochain.p2p.org/".to_string()),
+            devnet: Some("https://indexer.devnet.iota.cafe".to_string()),
+            testnet: Some("https://rpc.ankr.com/iota_testnet".to_string()),
+        };
+
+        iota_clients(Some(node_urls), None, None).await.unwrap();
+    }
+
+    /// This tests the underlying logic in our iota_clients() fn in a way that we can also make assertions.
+    #[tokio::test]
+    async fn test_iota_client_builder_node_urls() {
+        let mainnet = IotaClientBuilder::default()
+            .build("https://rpc.mainnet.iota.monochain.p2p.org/")
+            .await
+            .unwrap();
+        let devnet = IotaClientBuilder::default()
+            .build("https://indexer.devnet.iota.cafe")
+            .await
+            .unwrap();
+        let testnet = IotaClientBuilder::default()
+            .build("https://rpc.ankr.com/iota_testnet")
+            .await
+            .unwrap();
+
+        let main_http_str = format!("{:?}", mainnet.http());
+        let dev_http_str = format!("{:?}", devnet.http());
+        let test_http_str = format!("{:?}", testnet.http());
+
+        assert!(main_http_str.contains("https://rpc.mainnet.iota.monochain.p2p.org/"));
+        assert!(dev_http_str.contains("https://indexer.devnet.iota.cafe"));
+        assert!(test_http_str.contains("https://rpc.ankr.com/iota_testnet"));
+    }
 }

--- a/did_iota/src/consumer.rs
+++ b/did_iota/src/consumer.rs
@@ -66,17 +66,16 @@ pub struct NodeUrls {
 mod tests {
     use super::*;
 
-    /// This is a very basic test which simply checks wether the function completes without error.
-    /// All resulting structs are private in the identity.rs crates, therefore no assertions can be made.
-    /// See the second test for a more in-depth test.
     #[tokio::test]
-    async fn test_iota_clients_node_urls() {
+    async fn test_iota_clients_custom_node_config() {
         let node_urls = NodeUrls {
             mainnet: Some("https://rpc.mainnet.iota.monochain.p2p.org/".to_string()),
-            testnet: Some("https://rpc.ankr.com/iota_testnet".to_string()),
-            devnet: Some("https://indexer.devnet.iota.cafe".to_string()),
+            testnet: None,
+            devnet: None,
         };
 
-        iota_clients(None, Some(node_urls), None).await.unwrap();
+        let basic_auth = Some(("username", "password"));
+
+        let _ = iota_clients(None, Some(node_urls), basic_auth).await.unwrap();
     }
 }

--- a/did_iota/src/consumer.rs
+++ b/did_iota/src/consumer.rs
@@ -2,7 +2,8 @@ use identity_iota::iota::rebased::client::IdentityClientReadOnly;
 use identity_iota::iota::rebased::Error;
 use iota_sdk::{IotaClient, IotaClientBuilder};
 
-/// Builds clients for all IOTA networks with optional node URL and/or TLS confiuration, only returns an error if it fails to build, incorrect tls_config or node_url isn't caught before trying to build.
+/// Builds clients for all IOTA networks with optional node URL, TLS confiuration and basic authentication (username, password).
+/// Only returns an error if it fails to build, incorrect tls_config or node_urls aren't caught but simply defaults.
 pub async fn iota_clients(
     node_urls: Option<NodeUrls>,
     tls_config: Option<rustls::ClientConfig>,

--- a/did_iota/src/consumer.rs
+++ b/did_iota/src/consumer.rs
@@ -5,8 +5,8 @@ use iota_sdk::{IotaClient, IotaClientBuilder};
 /// Builds clients for all IOTA networks with optional node URL, TLS confiuration and basic authentication (username, password).
 /// Only returns an error if it fails to build, incorrect tls_config or node_urls aren't caught but simply defaults.
 pub async fn iota_clients(
-    node_urls: Option<NodeUrls>,
     tls_config: Option<rustls::ClientConfig>,
+    node_urls: Option<NodeUrls>,
     basic_auth: Option<(&str, &str)>,
 ) -> Result<Vec<(&'static str, IdentityClientReadOnly)>, Error> {
     let iota_mainnet: IotaClient;
@@ -76,7 +76,7 @@ mod tests {
             testnet: Some("https://rpc.ankr.com/iota_testnet".to_string()),
         };
 
-        iota_clients(Some(node_urls), None, None).await.unwrap();
+        iota_clients(None, Some(node_urls), None).await.unwrap();
     }
 
     /// This tests the underlying logic in our iota_clients() fn in a way that we can also make assertions.

--- a/did_iota/src/consumer.rs
+++ b/did_iota/src/consumer.rs
@@ -79,29 +79,4 @@ mod tests {
 
         iota_clients(None, Some(node_urls), None).await.unwrap();
     }
-
-    /// This tests the underlying logic in our iota_clients() fn in a way that we can also make assertions.
-    #[tokio::test]
-    async fn test_iota_client_builder_node_urls() {
-        let mainnet = IotaClientBuilder::default()
-            .build("https://rpc.mainnet.iota.monochain.p2p.org/")
-            .await
-            .unwrap();
-        let testnet = IotaClientBuilder::default()
-            .build("https://rpc.ankr.com/iota_testnet")
-            .await
-            .unwrap();
-        let devnet = IotaClientBuilder::default()
-            .build("https://indexer.devnet.iota.cafe")
-            .await
-            .unwrap();
-
-        let main_http_str = format!("{:?}", mainnet.http());
-        let test_http_str = format!("{:?}", testnet.http());
-        let dev_http_str = format!("{:?}", devnet.http());
-
-        assert!(main_http_str.contains("https://rpc.mainnet.iota.monochain.p2p.org/"));
-        assert!(test_http_str.contains("https://rpc.ankr.com/iota_testnet"));
-        assert!(dev_http_str.contains("https://indexer.devnet.iota.cafe"));
-    }
 }

--- a/did_iota/src/consumer.rs
+++ b/did_iota/src/consumer.rs
@@ -16,31 +16,31 @@ pub async fn iota_clients(
     basic_auth: Option<(&str, &str)>,
 ) -> Result<Vec<(&'static str, IdentityClientReadOnly)>, Error> {
     let iota_mainnet: IotaClient;
-    let iota_devnet: IotaClient;
     let iota_testnet: IotaClient;
+    let iota_devnet: IotaClient;
     if let Some(urls) = &node_urls {
         iota_mainnet = match &urls.mainnet {
             Some(url) => client_builder(tls_config.as_ref(), basic_auth).build(url).await?,
             None => client_builder(tls_config.as_ref(), basic_auth).build_mainnet().await?,
         };
-        iota_devnet = match &urls.devnet {
-            Some(url) => client_builder(tls_config.as_ref(), basic_auth).build(url).await?,
-            None => client_builder(tls_config.as_ref(), basic_auth).build_devnet().await?,
-        };
         iota_testnet = match &urls.testnet {
             Some(url) => client_builder(tls_config.as_ref(), basic_auth).build(url).await?,
             None => client_builder(tls_config.as_ref(), basic_auth).build_testnet().await?,
         };
+        iota_devnet = match &urls.devnet {
+            Some(url) => client_builder(tls_config.as_ref(), basic_auth).build(url).await?,
+            None => client_builder(tls_config.as_ref(), basic_auth).build_devnet().await?,
+        };
     } else {
         iota_mainnet = client_builder(tls_config.as_ref(), basic_auth).build_mainnet().await?;
-        iota_devnet = client_builder(tls_config.as_ref(), basic_auth).build_devnet().await?;
         iota_testnet = client_builder(tls_config.as_ref(), basic_auth).build_testnet().await?;
+        iota_devnet = client_builder(tls_config.as_ref(), basic_auth).build_devnet().await?;
     }
 
     Ok(vec![
         ("iota", IdentityClientReadOnly::new(iota_mainnet).await?),
-        ("devnet", IdentityClientReadOnly::new(iota_devnet).await?),
         ("testnet", IdentityClientReadOnly::new(iota_testnet).await?),
+        ("devnet", IdentityClientReadOnly::new(iota_devnet).await?),
     ])
 }
 
@@ -58,8 +58,8 @@ fn client_builder(tls_config: Option<&rustls::ClientConfig>, basic_auth: Option<
 #[derive(Debug, Clone)]
 pub struct NodeUrls {
     pub mainnet: Option<String>,
-    pub devnet: Option<String>,
     pub testnet: Option<String>,
+    pub devnet: Option<String>,
 }
 
 #[cfg(test)]
@@ -73,8 +73,8 @@ mod tests {
     async fn test_iota_clients_node_urls() {
         let node_urls = NodeUrls {
             mainnet: Some("https://rpc.mainnet.iota.monochain.p2p.org/".to_string()),
-            devnet: Some("https://indexer.devnet.iota.cafe".to_string()),
             testnet: Some("https://rpc.ankr.com/iota_testnet".to_string()),
+            devnet: Some("https://indexer.devnet.iota.cafe".to_string()),
         };
 
         iota_clients(None, Some(node_urls), None).await.unwrap();
@@ -87,21 +87,21 @@ mod tests {
             .build("https://rpc.mainnet.iota.monochain.p2p.org/")
             .await
             .unwrap();
-        let devnet = IotaClientBuilder::default()
-            .build("https://indexer.devnet.iota.cafe")
-            .await
-            .unwrap();
         let testnet = IotaClientBuilder::default()
             .build("https://rpc.ankr.com/iota_testnet")
             .await
             .unwrap();
+        let devnet = IotaClientBuilder::default()
+            .build("https://indexer.devnet.iota.cafe")
+            .await
+            .unwrap();
 
         let main_http_str = format!("{:?}", mainnet.http());
-        let dev_http_str = format!("{:?}", devnet.http());
         let test_http_str = format!("{:?}", testnet.http());
+        let dev_http_str = format!("{:?}", devnet.http());
 
         assert!(main_http_str.contains("https://rpc.mainnet.iota.monochain.p2p.org/"));
-        assert!(dev_http_str.contains("https://indexer.devnet.iota.cafe"));
         assert!(test_http_str.contains("https://rpc.ankr.com/iota_testnet"));
+        assert!(dev_http_str.contains("https://indexer.devnet.iota.cafe"));
     }
 }

--- a/did_iota/src/consumer.rs
+++ b/did_iota/src/consumer.rs
@@ -3,10 +3,7 @@ use identity_iota::iota::rebased::Error;
 use iota_sdk::IotaClientBuilder;
 
 // Helper to create a builder with optional TLS config AND/OR node url
-fn client_builder_with_tls_or_url(
-    tls_config: Option<&rustls::ClientConfig>,
-    node_url: Option<&str>,
-) -> IotaClientBuilder {
+fn client_builder(tls_config: Option<&rustls::ClientConfig>, node_url: Option<&str>) -> IotaClientBuilder {
     let mut builder = IotaClientBuilder::default();
     if let Some(url) = node_url {
         builder = builder.ws_url(url);
@@ -22,15 +19,9 @@ pub async fn iota_clients(
     node_url: Option<&str>,
     tls_config: Option<rustls::ClientConfig>,
 ) -> Result<Vec<(&'static str, IdentityClientReadOnly)>, Error> {
-    let iota_testnet = client_builder_with_tls_or_url(tls_config.as_ref(), node_url)
-        .build_testnet()
-        .await?;
-    let iota_devnet = client_builder_with_tls_or_url(tls_config.as_ref(), node_url)
-        .build_devnet()
-        .await?;
-    let iota_mainnet = client_builder_with_tls_or_url(tls_config.as_ref(), node_url)
-        .build_mainnet()
-        .await?;
+    let iota_testnet = client_builder(tls_config.as_ref(), node_url).build_testnet().await?;
+    let iota_devnet = client_builder(tls_config.as_ref(), node_url).build_devnet().await?;
+    let iota_mainnet = client_builder(tls_config.as_ref(), node_url).build_mainnet().await?;
 
     Ok(vec![
         ("testnet", IdentityClientReadOnly::new(iota_testnet).await?),

--- a/did_iota/src/consumer.rs
+++ b/did_iota/src/consumer.rs
@@ -7,58 +7,28 @@ use iota_sdk::{IotaClient, IotaClientBuilder};
 pub async fn iota_clients(
     node_urls: Option<NodeUrls>,
     tls_config: Option<rustls::ClientConfig>,
-    set_user_password: Option<(&str, &str)>,
+    basic_auth: Option<(&str, &str)>,
 ) -> Result<Vec<(&'static str, IdentityClientReadOnly)>, Error> {
     let iota_mainnet: IotaClient;
     let iota_devnet: IotaClient;
     let iota_testnet: IotaClient;
     if let Some(urls) = &node_urls {
         iota_mainnet = match &urls.mainnet {
-            Some(url) => {
-                client_builder(tls_config.as_ref(), set_user_password)
-                    .build(url)
-                    .await?
-            }
-            None => {
-                client_builder(tls_config.as_ref(), set_user_password)
-                    .build_mainnet()
-                    .await?
-            }
+            Some(url) => client_builder(tls_config.as_ref(), basic_auth).build(url).await?,
+            None => client_builder(tls_config.as_ref(), basic_auth).build_mainnet().await?,
         };
         iota_devnet = match &urls.devnet {
-            Some(url) => {
-                client_builder(tls_config.as_ref(), set_user_password)
-                    .build(url)
-                    .await?
-            }
-            None => {
-                client_builder(tls_config.as_ref(), set_user_password)
-                    .build_devnet()
-                    .await?
-            }
+            Some(url) => client_builder(tls_config.as_ref(), basic_auth).build(url).await?,
+            None => client_builder(tls_config.as_ref(), basic_auth).build_devnet().await?,
         };
         iota_testnet = match &urls.testnet {
-            Some(url) => {
-                client_builder(tls_config.as_ref(), set_user_password)
-                    .build(url)
-                    .await?
-            }
-            None => {
-                client_builder(tls_config.as_ref(), set_user_password)
-                    .build_testnet()
-                    .await?
-            }
+            Some(url) => client_builder(tls_config.as_ref(), basic_auth).build(url).await?,
+            None => client_builder(tls_config.as_ref(), basic_auth).build_testnet().await?,
         };
     } else {
-        iota_mainnet = client_builder(tls_config.as_ref(), set_user_password)
-            .build_mainnet()
-            .await?;
-        iota_devnet = client_builder(tls_config.as_ref(), set_user_password)
-            .build_devnet()
-            .await?;
-        iota_testnet = client_builder(tls_config.as_ref(), set_user_password)
-            .build_testnet()
-            .await?;
+        iota_mainnet = client_builder(tls_config.as_ref(), basic_auth).build_mainnet().await?;
+        iota_devnet = client_builder(tls_config.as_ref(), basic_auth).build_devnet().await?;
+        iota_testnet = client_builder(tls_config.as_ref(), basic_auth).build_testnet().await?;
     }
 
     Ok(vec![
@@ -71,15 +41,12 @@ pub async fn iota_clients(
 // Helpers
 
 // Helper to create a builder with optional TLS config and basic_auth configuration
-fn client_builder(
-    tls_config: Option<&rustls::ClientConfig>,
-    set_user_password: Option<(&str, &str)>,
-) -> IotaClientBuilder {
+fn client_builder(tls_config: Option<&rustls::ClientConfig>, basic_auth: Option<(&str, &str)>) -> IotaClientBuilder {
     let mut builder = IotaClientBuilder::default();
     if let Some(cfg) = tls_config {
         builder = builder.tls_config(cfg.clone());
     }
-    if let Some((username, password)) = set_user_password {
+    if let Some((username, password)) = basic_auth {
         builder = builder.basic_auth(username, password);
     }
     builder

--- a/did_iota/src/consumer.rs
+++ b/did_iota/src/consumer.rs
@@ -17,7 +17,7 @@ fn client_builder_with_tls_or_url(
     builder
 }
 
-/// Builds clients for all IOTA networks with optional node URL and/or TLS config.
+/// Builds clients for all IOTA networks with optional node URL and/or TLS config, only returns an error if it fails to build, incorrect tls_config or node_url isn't caught before trying to build.
 pub async fn iota_clients(
     node_url: Option<&str>,
     tls_config: Option<rustls::ClientConfig>,

--- a/did_iota/src/consumer.rs
+++ b/did_iota/src/consumer.rs
@@ -2,8 +2,14 @@ use identity_iota::iota::rebased::client::IdentityClientReadOnly;
 use identity_iota::iota::rebased::Error;
 use iota_sdk::{IotaClient, IotaClientBuilder};
 
-/// Builds clients for all IOTA networks with optional node URL, TLS confiuration and basic authentication (username, password).
-/// Only returns an error if it fails to build, incorrect tls_config or node_urls aren't caught but simply defaults.
+/// Builds clients for all IOTA networks.
+///
+/// Parameters:
+/// - TLS configuration (optional)
+/// - Node URLs (optional)
+/// - Basic Authentication (optional)
+///
+/// This function only returns an error if it fails to build. The provided values are not validated.
 pub async fn iota_clients(
     tls_config: Option<rustls::ClientConfig>,
     node_urls: Option<NodeUrls>,
@@ -38,9 +44,6 @@ pub async fn iota_clients(
     ])
 }
 
-// Helpers
-
-// Helper to create a builder with optional TLS config and basic_auth configuration
 fn client_builder(tls_config: Option<&rustls::ClientConfig>, basic_auth: Option<(&str, &str)>) -> IotaClientBuilder {
     let mut builder = IotaClientBuilder::default();
     if let Some(cfg) = tls_config {
@@ -52,8 +55,6 @@ fn client_builder(tls_config: Option<&rustls::ClientConfig>, basic_auth: Option<
     builder
 }
 
-/// This struct is to strictly define what is passed as an argument to fn iota_clients()
-/// If None is passed the IOTA default node for that net will be used.
 #[derive(Debug, Clone)]
 pub struct NodeUrls {
     pub mainnet: Option<String>,

--- a/did_iota/src/producer/resolve.rs
+++ b/did_iota/src/producer/resolve.rs
@@ -4,7 +4,7 @@ use crate::consumer::iota_clients;
 
 pub async fn resolve(did: IotaDID) -> Result<CoreDocument, anyhow::Error> {
     let mut resolver = Resolver::<CoreDocument>::new();
-    resolver.attach_multiple_iota_handlers(iota_clients(None).await.unwrap());
+    resolver.attach_multiple_iota_handlers(iota_clients(None, None).await.unwrap());
     let document = resolver.resolve(&did).await?;
     Ok(document)
 }

--- a/did_iota/src/producer/resolve.rs
+++ b/did_iota/src/producer/resolve.rs
@@ -4,7 +4,7 @@ use crate::consumer::iota_clients;
 
 pub async fn resolve(did: IotaDID) -> Result<CoreDocument, anyhow::Error> {
     let mut resolver = Resolver::<CoreDocument>::new();
-    resolver.attach_multiple_iota_handlers(iota_clients(None, None).await.unwrap());
+    resolver.attach_multiple_iota_handlers(iota_clients(None, None, None).await.unwrap());
     let document = resolver.resolve(&did).await?;
     Ok(document)
 }


### PR DESCRIPTION
# Description of change
The resolver needs to be easily configurable with any IOTA node url. Custom node urls often require basic authentication as well, so this has been made configurable too.

## Links to any relevant issues

## How the change has been tested
I've added new unit tests.
Old tests still pass.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes