### PR TITLE
fix: prevent panic on IOTA connection failure via lazy initialization

### DIFF
--- a/consumer/src/resolver.rs
+++ b/consumer/src/resolver.rs
@@ -9,14 +9,14 @@ use shared::error::ConsumerError;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct ResolverConfig {
     tls_config: Option<rustls::ClientConfig>,
     node_urls: Option<NodeUrls>,
     basic_auth: Option<(String, String)>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Resolver {
     // We store the config so that we can initialize the resolver lazily
     config: ResolverConfig,
@@ -28,15 +28,7 @@ pub struct Resolver {
 
 impl Resolver {
     pub fn new() -> Self {
-        Self {
-            config: ResolverConfig {
-                tls_config: None,
-                node_urls: None,
-                basic_auth: None,
-            },
-            resolver: RwLock::new(None),
-            iota_clients: RwLock::new(IotaClients::default()),
-        }
+        Self::default()
     }
 
     pub fn new_with_options(

--- a/consumer/src/resolver.rs
+++ b/consumer/src/resolver.rs
@@ -119,6 +119,10 @@ impl Resolver {
             *resolver_guard = Some(new_arc.clone());
             resolver_arc = new_arc;
 
+            // TODO: We should optimize this by making sure prior attached handlers are preserved when we reinitialize the resolver with a new client.
+            // Reset the initialization flags for all networks, since we are reinitializing the resolver with a new client.
+            *clients_guard = IotaClients::default();
+
             // Update flags
             match network_name {
                 "testnet" => clients_guard.testnet = true,

--- a/consumer/src/resolver.rs
+++ b/consumer/src/resolver.rs
@@ -179,7 +179,49 @@ mod tests {
             "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL"
         );
 
+        let did = "did:jwk:eyJhbGciOiJFZERTQSIsImNydiI6IkVkMjU1MTkiLCJraWQiOiJTRklDVzczSEN3Sm9CVENpQUNGMUUzV21yaDVMRTB4al9HMUpWU2VYUy1NIiwia3R5IjoiT0tQIiwieCI6IjZCeG92MWxoSFltQVVHMWNibDM1eUcyYzZtcFpsOVdkeXNqSUhhSjdhODgifQ";
+        let document = resolver.resolve(did).await.unwrap();
+
+        assert_eq!(document.id().to_string(), did);
+
         // TODO: add more ...
+    }
+
+    #[test(tokio::test)]
+    async fn concurrent_resolutions_do_not_deadlock() {
+        let resolver = Arc::new(Resolver::new());
+        let did = "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL";
+
+        let mut handles = vec![];
+        for _ in 0..50 {
+            let resolver_clone = resolver.clone();
+            handles.push(tokio::spawn(async move { resolver_clone.resolve(did).await }));
+        }
+
+        for handle in handles {
+            let result = handle.await.unwrap();
+            assert!(result.is_ok(), "Concurrent resolution failed: {:?}", result.err());
+        }
+    }
+
+    #[test(tokio::test)]
+    async fn iota_failure_does_not_break_basic_resolver() {
+        // This test simulates a scenario where IOTA resolution might fail (due to network or config),
+        // but validates that basic methods (key/jwk) continue to work.
+        let resolver = Resolver::new();
+
+        // 1. Resolve basic DID successfully
+        let key_did = "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL";
+        assert!(resolver.resolve(key_did).await.is_ok());
+
+        // 2. Attempt invalid IOTA network resolution
+        // Note: Unless we have a real network, this will likely fail or timeout.
+        // We just want to ensure it doesn't panic or poison the resolver for future calls.
+        let iota_did = "did:iota:testnet:0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let _ = resolver.resolve(iota_did).await; // We ignore the result, potentially Err
+
+        // 3. Resolve basic DID again - should still succeed
+        assert!(resolver.resolve(key_did).await.is_ok());
     }
 
     #[test(tokio::test)]

--- a/consumer/src/resolver.rs
+++ b/consumer/src/resolver.rs
@@ -1,60 +1,165 @@
-use did_iota::consumer::{iota_clients, NodeUrls};
+use did_iota::consumer::{get_iota_client, IotaClients, NodeUrls};
 use did_jwk::consumer::resolve_did_jwk;
 use did_key::consumer::resolve_did_key;
 use did_web::consumer::resolve_did_web;
-use identity_iota::did::CoreDID;
+use identity_iota::did::{CoreDID, DID as _};
 use identity_iota::document::CoreDocument;
 use identity_iota::resolver::Resolver as IdentityResolver;
 use shared::error::ConsumerError;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[derive(Debug)]
+struct ResolverConfig {
+    tls_config: Option<rustls::ClientConfig>,
+    node_urls: Option<NodeUrls>,
+    basic_auth: Option<(String, String)>,
+}
 
 #[derive(Debug)]
 pub struct Resolver {
-    pub(crate) resolver: IdentityResolver,
+    // We store the config so that we can initialize the resolver lazily
+    config: ResolverConfig,
+
+    iota_clients: RwLock<IotaClients>,
+    // We use an RwLock to allow concurrent reads, but exclusive access for initialization
+    resolver: RwLock<Option<Arc<IdentityResolver>>>,
 }
 
 impl Resolver {
-    pub async fn new() -> Self {
-        let resolver = configure_resolver(IdentityResolver::new(), None, None, None)
-            .await
-            .expect("Failed to configure resolver");
-        Self { resolver }
+    pub fn new() -> Self {
+        Self {
+            config: ResolverConfig {
+                tls_config: None,
+                node_urls: None,
+                basic_auth: None,
+            },
+            resolver: RwLock::new(None),
+            iota_clients: RwLock::new(IotaClients::default()),
+        }
     }
 
-    pub async fn new_with_options(
+    pub fn new_with_options(
         tls_config: Option<rustls::ClientConfig>,
         node_urls: Option<NodeUrls>,
         basic_auth: Option<(&str, &str)>,
     ) -> Self {
-        let resolver = configure_resolver(IdentityResolver::new(), tls_config, node_urls, basic_auth)
+        Self {
+            config: ResolverConfig {
+                tls_config,
+                node_urls,
+                // Convert &str to String because we need to own the data for future initialization
+                basic_auth: basic_auth.map(|(u, p)| (u.to_string(), p.to_string())),
+            },
+            resolver: RwLock::new(None),
+            iota_clients: RwLock::new(IotaClients::default()),
+        }
+    }
+
+    /// This function returns the `Resolver` instance if it exists, or initializes it if it doesn't. It also ensures
+    /// that the appropriate IOTA handler is attached based on the authority. The 'basic' handlers (jwk, key, web) are
+    /// always attached in the base `Resolver`, but the IOTA handlers are only attached when needed. This way we avoid
+    /// the initialization of the IOTA client and handler for non-IOTA DIDs, and we only initialize the specific IOTA
+    /// client when we encounter a DID that requires it.
+    async fn get_or_init_resolver(&self, authority: &str) -> Result<Arc<IdentityResolver>, ConsumerError> {
+        // Ensure the basic resolver exists first
+        let basic_resolver_opt = self.resolver.read().await.clone();
+
+        let mut resolver_arc = if let Some(resolver) = basic_resolver_opt {
+            resolver
+        } else {
+            let mut guard = self.resolver.write().await;
+            if let Some(resolver) = guard.as_ref() {
+                resolver.clone()
+            } else {
+                // Initialize the basic resolver with non-IOTA handlers (jwk, key, web).
+                let mut resolver = IdentityResolver::new();
+                Self::add_basic_handlers(&mut resolver);
+                let arc = Arc::new(resolver);
+                *guard = Some(arc.clone());
+                arc
+            }
+        };
+
+        // Determine if this is an IOTA request
+        if !authority.starts_with("iota:") {
+            return Ok(resolver_arc);
+        }
+
+        // Determine the network parameters based on the authority prefix.
+        let (network_name, get_node_url): (&str, fn(&NodeUrls) -> Option<String>) =
+            if authority.starts_with("iota:testnet:") {
+                ("testnet", |urls| urls.testnet.clone())
+            } else if authority.starts_with("iota:devnet:") {
+                ("devnet", |urls| urls.devnet.clone())
+            } else {
+                ("iota", |urls| urls.mainnet.clone())
+            };
+
+        // Acquire write lock immediately to check and initialize
+        let mut clients_guard = self.iota_clients.write().await;
+
+        let needs_initialization = match network_name {
+            "testnet" => !clients_guard.testnet,
+            "devnet" => !clients_guard.devnet,
+            _ => !clients_guard.mainnet,
+        };
+
+        if needs_initialization {
+            let node_url = self.config.node_urls.as_ref().and_then(get_node_url);
+
+            let iota_client = get_iota_client(
+                network_name,
+                self.config.tls_config.clone(),
+                node_url,
+                self.config.basic_auth.as_ref().map(|(u, p)| (u.as_str(), p.as_str())),
+            )
             .await
-            .expect("Failed to configure resolver");
-        Self { resolver }
+            .ok_or_else(|| ConsumerError::Generic(format!("Failed to initialize IOTA client: {}", network_name)))?;
+
+            // Reconstruct resolver with new client
+            let mut resolver_guard = self.resolver.write().await;
+            let mut new_resolver = IdentityResolver::new();
+            Self::add_basic_handlers(&mut new_resolver);
+            new_resolver.attach_iota_handler(iota_client);
+
+            let new_arc = Arc::new(new_resolver);
+            *resolver_guard = Some(new_arc.clone());
+            resolver_arc = new_arc;
+
+            // Update flags
+            match network_name {
+                "testnet" => clients_guard.testnet = true,
+                "devnet" => clients_guard.devnet = true,
+                _ => clients_guard.mainnet = true,
+            }
+        } else {
+            // Already initialized.
+            // We need to fetch the current resolver. We can take a read lock on it.
+            // Note: We still hold clients_guard here, ensuring no one else is modifying the structure while we read.
+            if let Some(current) = self.resolver.read().await.clone() {
+                resolver_arc = current;
+            }
+        }
+
+        Ok(resolver_arc)
+    }
+
+    fn add_basic_handlers(resolver: &mut IdentityResolver) {
+        resolver.attach_handler("jwk".to_owned(), resolve_did_jwk);
+        resolver.attach_handler("key".to_owned(), resolve_did_key);
+        resolver.attach_handler("web".to_owned(), resolve_did_web);
     }
 
     pub async fn resolve(&self, did: &str) -> Result<CoreDocument, ConsumerError> {
-        let did = CoreDID::parse(did)?;
-        let document: CoreDocument = self.resolver.resolve(&did).await?;
+        let did: CoreDID = CoreDID::parse(did)?;
+
+        // Ensure resolver is initialized
+        let resolver = self.get_or_init_resolver(did.authority()).await?;
+
+        let document: CoreDocument = resolver.resolve(&did).await?;
         Ok(document)
     }
-}
-
-async fn configure_resolver(
-    mut resolver: IdentityResolver,
-    tls_config: Option<rustls::ClientConfig>,
-    node_urls: Option<NodeUrls>,
-    basic_auth: Option<(&str, &str)>,
-) -> Result<IdentityResolver, ConsumerError> {
-    resolver.attach_handler("jwk".to_owned(), resolve_did_jwk);
-    resolver.attach_handler("key".to_owned(), resolve_did_key);
-    resolver.attach_handler("web".to_owned(), resolve_did_web);
-
-    resolver.attach_multiple_iota_handlers(
-        iota_clients(tls_config, node_urls, basic_auth)
-            .await
-            .map_err(|e| ConsumerError::Generic(format!("Failed to attach IOTA handlers: {e}")))?,
-    );
-
-    Ok(resolver)
 }
 
 #[cfg(test)]
@@ -65,7 +170,7 @@ mod tests {
 
     #[test(tokio::test)]
     async fn resolve_all_supported_methods() {
-        let resolver = Resolver::new().await;
+        let resolver = Resolver::new();
         let did = "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL";
         let document = resolver.resolve(did).await.unwrap();
 
@@ -79,7 +184,7 @@ mod tests {
 
     #[test(tokio::test)]
     async fn fails_on_unsupported_method() {
-        let resolver = Resolver::new().await;
+        let resolver = Resolver::new();
         let did = "did:foo:bar";
         let result = resolver.resolve(did).await;
 
@@ -89,7 +194,7 @@ mod tests {
     #[ignore]
     #[test(tokio::test)]
     async fn resolves_did_iota() {
-        let resolver = Resolver::new().await;
+        let resolver = Resolver::new();
         let did = "did:iota:0xe4edef97da1257e83cbeb49159cfdd2da6ac971ac447f233f8439cf29376ebfe";
         let document = resolver.resolve(did).await.unwrap();
 

--- a/did_iota/src/consumer.rs
+++ b/did_iota/src/consumer.rs
@@ -1,58 +1,48 @@
 use identity_iota::iota::rebased::client::IdentityClientReadOnly;
-use identity_iota::iota::rebased::Error;
-use iota_sdk::{IotaClient, IotaClientBuilder};
+use iota_sdk::IotaClientBuilder;
 
-/// Builds clients for all IOTA networks.
+/// Builds client for the specified IOTA network with optional TLS configuration, node URLs, and basic authentication.
 ///
 /// Parameters:
 /// - TLS configuration (optional)
-/// - Node URLs (optional)
+/// - Node URL (optional)
 /// - Basic Authentication (optional)
 ///
-/// This function only returns an error if it fails to build. The provided values are not validated.
-pub async fn iota_clients(
+/// This function returns an `IdentityClientReadOnly` instance if the client is successfully built, or `None` if there was an error during initialization.
+pub async fn get_iota_client(
+    network: &str,
     tls_config: Option<rustls::ClientConfig>,
-    node_urls: Option<NodeUrls>,
+    node_url: Option<String>,
     basic_auth: Option<(&str, &str)>,
-) -> Result<Vec<(&'static str, IdentityClientReadOnly)>, Error> {
-    let iota_mainnet: IotaClient;
-    let iota_testnet: IotaClient;
-    let iota_devnet: IotaClient;
-    if let Some(urls) = &node_urls {
-        iota_mainnet = match &urls.mainnet {
-            Some(url) => client_builder(tls_config.as_ref(), basic_auth).build(url).await?,
-            None => client_builder(tls_config.as_ref(), basic_auth).build_mainnet().await?,
-        };
-        iota_testnet = match &urls.testnet {
-            Some(url) => client_builder(tls_config.as_ref(), basic_auth).build(url).await?,
-            None => client_builder(tls_config.as_ref(), basic_auth).build_testnet().await?,
-        };
-        iota_devnet = match &urls.devnet {
-            Some(url) => client_builder(tls_config.as_ref(), basic_auth).build(url).await?,
-            None => client_builder(tls_config.as_ref(), basic_auth).build_devnet().await?,
-        };
-    } else {
-        iota_mainnet = client_builder(tls_config.as_ref(), basic_auth).build_mainnet().await?;
-        iota_testnet = client_builder(tls_config.as_ref(), basic_auth).build_testnet().await?;
-        iota_devnet = client_builder(tls_config.as_ref(), basic_auth).build_devnet().await?;
-    }
-
-    Ok(vec![
-        ("iota", IdentityClientReadOnly::new(iota_mainnet).await?),
-        ("testnet", IdentityClientReadOnly::new(iota_testnet).await?),
-        ("devnet", IdentityClientReadOnly::new(iota_devnet).await?),
-    ])
-}
-
-fn client_builder(tls_config: Option<&rustls::ClientConfig>, basic_auth: Option<(&str, &str)>) -> IotaClientBuilder {
+) -> Option<IdentityClientReadOnly> {
     let mut builder = IotaClientBuilder::default();
+
     if let Some(cfg) = tls_config {
-        builder = builder.tls_config(cfg.clone());
+        builder = builder.tls_config(cfg);
     }
     if let Some((username, password)) = basic_auth {
         builder = builder.basic_auth(username, password);
     }
-    builder
+
+    let iota_client = if let Some(node_url) = &node_url {
+        builder.build(node_url).await.ok()?
+    } else {
+        match network {
+            "iota" => builder.build_mainnet().await.ok()?,
+            "testnet" => builder.build_testnet().await.ok()?,
+            "devnet" => builder.build_devnet().await.ok()?,
+            _ => return None,
+        }
+    };
+
+    IdentityClientReadOnly::new(iota_client).await.ok()
+}
+
+#[derive(Debug, Default)]
+pub struct IotaClients {
+    pub mainnet: bool,
+    pub testnet: bool,
+    pub devnet: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -68,14 +58,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_iota_clients_custom_node_config() {
-        let node_urls = NodeUrls {
-            mainnet: Some("https://rpc.mainnet.iota.monochain.p2p.org/".to_string()),
-            testnet: None,
-            devnet: None,
-        };
-
         let basic_auth = Some(("username", "password"));
 
-        let _ = iota_clients(None, Some(node_urls), basic_auth).await.unwrap();
+        let _ = get_iota_client(
+            "iota",
+            None,
+            Some("https://rpc.mainnet.iota.monochain.p2p.org/".to_string()),
+            basic_auth,
+        )
+        .await
+        .unwrap();
     }
 }

--- a/did_iota/src/producer/resolve.rs
+++ b/did_iota/src/producer/resolve.rs
@@ -1,10 +1,18 @@
-use identity_iota::{document::CoreDocument, iota::IotaDID, resolver::Resolver};
+use identity_iota::{did::DID as _, document::CoreDocument, iota::IotaDID, resolver::Resolver};
 
-use crate::consumer::iota_clients;
+use crate::consumer::get_iota_client;
 
 pub async fn resolve(did: IotaDID) -> Result<CoreDocument, anyhow::Error> {
     let mut resolver = Resolver::<CoreDocument>::new();
-    resolver.attach_multiple_iota_handlers(iota_clients(None, None, None).await.unwrap());
+
+    let authority = did.authority();
+
+    let iota_client = get_iota_client(authority, None, None, None)
+        .await
+        .ok_or_else(|| anyhow::anyhow!("Failed to get IOTA client for authority `{authority}`"))?;
+
+    resolver.attach_iota_handler(iota_client);
+
     let document = resolver.resolve(&did).await?;
     Ok(document)
 }


### PR DESCRIPTION
# Description of change
Restructures the `Resolver` to initialize IOTA network clients lazily instead of eagerly at startup.

Changes:

* Updated `Resolver` to use `RwLock` and double-checked locking for on-demand initialization.
  * Split `iota_clients` into a single-network `get_iota_client` helper. (ensures that one failing IOTA network (client) does not affect initialization of the other IOTA network client initialization)
  * Basic handlers (JWK, Key, Web) are now always available immediately.
  * Fixed an issue where IOTA connection failures could block non-IOTA DID resolution.
* Benefits:
  * Faster startup for non-IOTA use cases.
  * Improved resilience: unrelated IOTA errors no longer affect other DID methods.

## Links to any relevant issues
`Resolver::new` panicking on startup in `identity-wallet` and `ssi-agent`.

## How the change has been tested
Added unit tests:
- `concurrent_resolutions_do_not_deadlock`
- `iota_failure_does_not_break_basic_resolver`

Tested startup 'manually' in [identity-wallet](https://github.com/impierce/identity-wallet/pull/708) and [ssi-agent](https://github.com/impierce/ssi-agent/pull/295).

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes